### PR TITLE
Reporter should use buffered channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,16 +355,38 @@ implementation:
 
 ```clojure
 (let [chan (async/chan)]
-    (http/post (str "http://example.com/api/user/register")
-        {:body    (json/encode {:email email :password password})
-         :async?  true
-         :headers {:content-type "application/json"
-                   :accept       "application/json"}}
-        #(if-let [result (some-> % :body (json/decode true))]
-           (put! chan result)
-           (close! chan))
-        #(put! chan %))
-    chan)
+  (http/post (str "http://example.com/api/user/register")
+    {:body    (json/encode {:email email :password password})
+     :async?  true
+     :headers {:content-type "application/json"
+               :accept       "application/json"}}
+    #(if-let [result (some-> % :body (json/decode true))]
+       (put! chan result)
+       (close! chan))
+    #(put! chan %))
+  chan)
+```
+
+#### Reporter
+
+When starting `io.vouch.load-tests.master` one of required config elements is reporter. It must be a `core.async`
+channel. Keep in mind that you can put only 1024 pending messages on the channel, so if you have more actors than you
+should provide a buffer to the channel.
+
+This results in an exception:
+
+```clojure
+(let [c (clojure.core.async/chan)]
+  (doseq [_ (range 1025)]
+    (clojure.core.async/go (clojure.core.async/put! c 1))))
+```
+
+While this is perfectly fine:
+
+```clojure
+(let [c (clojure.core.async/chan 2222)]
+  (doseq [_ (range 2222)]
+    (clojure.core.async/go (clojure.core.async/put! c 1))))
 ```
 
 ## Development
@@ -374,3 +396,4 @@ In order to run sample tests:
     clj -A:dev
     (dev)
     (reset)
+             

--- a/dev/dev.clj
+++ b/dev/dev.clj
@@ -28,11 +28,15 @@
                  {:workflow :listeners :actors 1 :tags [:singleton]}
                  {:workflow :inviter :actors 10}]})
 
+(defn- count-actors
+  [scenario]
+  (reduce #(+ %1 (:actors %2)) 0 (:actor-pools scenario)))
+
 (defn go []
   (reset! server
     (let [jetty  (jetty/run-jetty sample-backend/handler {:port 3000 :join? false})
-          system (core/start-system {:reporter   #_(reporter/create-csv-reporter "output.csv")
-                                               (reporter/create-log-reporter)
+          system (core/start-system {:reporter   #_(reporter/create-csv-reporter "output.csv" (count-actors scenario) true)
+                                     (reporter/create-log-reporter (count-actors scenario))
                                      :api-url  "http://localhost:3000/api"
                                      :scenario scenario})]
       (reify Closeable


### PR DESCRIPTION
This allows overcoming:
Assert failed: No more than 1024 pending puts are allowed on a single channel. Consider using a windowed buffer.
(< (.size puts) impl/MAX-QUEUE-SIZE)