### PR TITLE
Multiply duration of wait task by executor index

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ responsible for providing implementation of the task. The framework ships with a
 I.e. `{:task :wait :duration 5}` the `wait` task requires `duration` property.
 
 ```clojure
-(defmethod io.vouch.load-tests.executor/execute-task :wait
-  [{:keys [id] :as executor} {:keys [duration] :as task}]
+(defmethod executor/execute-task :wait
+  [{:keys [id index]} {:keys [duration multiply-by-index] :as msg}]
   (go
-    (log/info id task)
-    (<! (timeout (* 1000 duration)))))
+    (log/info id msg)
+    (<! (timeout (* duration (if (true? multiply-by-index) index 1))))))
 ```
 
 ## Handling task failure
@@ -307,6 +307,8 @@ Pause executor for a duration of time. Default unit is seconds.
 {:task :wait :duration 500 :unit :milliseconds} ; wait 500 milliseconds
 {:task :wait :duration 1 :unit :minutes} ; wait 1 minute
 {:task :wait :duration [3 8]} ; wait random duration between 3 and 8 seconds
+{:task :wait :duration 2 :multiply-by :index} ; first executor (index=0) waits 0 seconds, second executor (index=1) waits 1*2 seconds, third executor (index=2) waits 2*2 seconds
+{:task :wait :duration 2 :multiply-by :reversed-index} ; given there are 3 executors: first executor (index=0) waits (3-1-0)*2 seconds, second executor (index=1) waits (3-1-1)*2 seconds, third executor (index=2) waits (3-1-2)*2 seconds
 ```
 
 ### Loop task

--- a/src/io/vouch/load_tests/master.clj
+++ b/src/io/vouch/load_tests/master.clj
@@ -23,13 +23,15 @@
             schedule-completions (atom [])]
         (doseq [{:keys [workflow actors] :as pool} actor-pools]
           (doseq [_ (range actors)]
-            (let [executor (executor/create
+            (let [index    (count @executors)
+                  executor (executor/create
                              (-> config
                                  (assoc :reporter reporter)
                                  (assoc :terminate-scenario #(close! terminator))
                                  (dissoc :create-executor-state)
                                  (merge (dissoc pool :actors))
-                                 (assoc :id (str "executor-" (count @executors) "-" workflow)
+                                 (assoc :id (str "executor-" index "-" workflow)
+                                        :index index
                                         :get-executors #(deref executors)
                                         :state (atom (merge
                                                        {}

--- a/src/io/vouch/load_tests/task/wait.clj
+++ b/src/io/vouch/load_tests/task/wait.clj
@@ -6,10 +6,13 @@
     [io.vouch.load-tests.task.definition.converter :as definition-converter]))
 
 (defmethod executor/execute-task :wait
-  [{:keys [id]} {:keys [duration] :as msg}]
+  [{:keys [id index get-executors]} {:keys [duration multiply-by] :as msg}]
   (go
-    (log/info id msg)
-    (<! (timeout duration))))
+    (let [duration (cond-> duration
+                           (= :index multiply-by) (* index)
+                           (= :reversed-index multiply-by) (* (- (count (get-executors)) 1 index)))]
+      (log/info id "waiting for" duration msg)
+      (<! (timeout duration)))))
 
 (defmethod definition-converter/task-definition->task :wait
   [definition]


### PR DESCRIPTION
When there are a lot of executors involved in a scenario and we want to avoid them executing certain action all at once, we should be able to distribute the execution over time.
To achieve that the `:wait` task accepts `:multiply-by` property to multiplay the duration by executor `:index` or `:reversed-index`:

```clojure
{:task :wait :duration 2 :multiply-by :index}
{:task :wait :duration 2 :multiply-by :reversed-index}
```